### PR TITLE
Implement robust way to get the correct kernel argument names.

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLProgram.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLProgram.java
@@ -2,6 +2,7 @@ package net.haesleinhuepf.clij.clearcl;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,7 +31,7 @@ public class ClearCLProgram implements AutoCloseable
   private final ConcurrentHashMap<String, String> mDefinesMap =
                                                               new ConcurrentHashMap<>();
   private final ArrayList<String> mBuildOptionsList =
-                                                    new ArrayList<>();
+                                                    new ArrayList<>(Collections.singletonList("-cl-kernel-arg-info"));
   private final ArrayList<String> mIncludesSearchPackages =
                                                           new ArrayList<>();
 

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/backend/ClearCLBackendInterface.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/backend/ClearCLBackendInterface.java
@@ -337,6 +337,26 @@ public interface ClearCLBackendInterface
                          int pIndex,
                          Object pObject);
 
+
+  /**
+   * Returns the number of arguments of the given kernel.
+   *
+   * @param pKernelPeerPointer
+   *          kernel peer pointer
+   */
+  int getNumberOfKernelArguments(ClearCLPeerPointer pKernelPeerPointer);
+
+  /**
+   * Returns the name of a kernel argument.
+   *
+   * @param pKernelPeerPointer
+   *          kernel peer pointer
+   * @param pIndex
+   *          argument index
+   */
+  String getKernelArgumentName(ClearCLPeerPointer pKernelPeerPointer,
+                               int pIndex);
+
   /**
    * Enqueues execution of a kernel on a given queue for a set of kernel run
    * parameters

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCL.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCL.java
@@ -1,6 +1,7 @@
 package net.haesleinhuepf.clij.clearcl.backend.jocl;
 
 import static org.jocl.CL.CL_CONTEXT_PLATFORM;
+import static org.jocl.CL.CL_KERNEL_ARG_NAME;
 import static org.jocl.CL.clBuildProgram;
 import static org.jocl.CL.clCreateBuffer;
 import static org.jocl.CL.clCreateCommandQueue;
@@ -721,6 +722,34 @@ public class ClearCLBackendJOCL extends ClearCLBackendBase
       }
     });
 
+  }
+
+  @Override
+  public int getNumberOfKernelArguments(ClearCLPeerPointer pKernelPeerPointer) {
+    int[] lValue = new int[1];
+  	BackendUtils.checkExceptions(() -> {
+      BackendUtils.checkOpenCLError(CL.clGetKernelInfo((cl_kernel) pKernelPeerPointer.getPointer(),
+              CL.CL_KERNEL_NUM_ARGS,
+              4,
+              Pointer.to(lValue),
+              new long[1]));
+    });
+    return lValue[0];
+  }
+
+  @Override
+  public String getKernelArgumentName(ClearCLPeerPointer pKernelPeerPointer, int pIndex) {
+    byte[] lBytes = new byte[200];
+    long[] lNumberOfBytesUsed = new long[1];
+    BackendUtils.checkExceptions(() -> {
+      BackendUtils.checkOpenCLError(CL.clGetKernelArgInfo((cl_kernel) pKernelPeerPointer.getPointer(),
+                                                          pIndex,
+                                                          CL_KERNEL_ARG_NAME,
+                                                          lBytes.length,
+                                                          Pointer.to(lBytes),
+                                                          lNumberOfBytesUsed));
+    });
+    return new String(lBytes, 0, (int) lNumberOfBytesUsed[0] - 1);
   }
 
   @Override


### PR DESCRIPTION
The current implementation of ClearCLKernel.getKernelIndexMap(...) gets easily confused when defines are used in the kernel arguments. The following example shows a perfectly fine kernel that can not be executed with CLIJ.
```java
#define IMAGE_TYPE(x) IMAGE_ ## x ##_TYPE x

__kernel void setOne(IMAGE_TYPE(dst)) {
   ...
}
```

The problem is caused by this [code](https://github.com/clij/clij-clearcl/blob/master/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLKernel.java#L607-L630), which tries to query the kernel argument names by parsing the source code. That's a difficult and error prone approach.

This PR instead uses the OpenCL API's function for querying the kernel argument names: https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelArgInfo.html 
