### PR TITLE
Small Changes

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLKernel.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLKernel.java
@@ -299,6 +299,11 @@ public class ClearCLKernel extends ClearCLBase
     setArgument(lArgumentIndex, pObject);
   }
 
+  public boolean hasArgument(final String pArgumentName) {
+    return mNameToIndexMap.containsKey(pArgumentName);
+  }
+
+
   /**
    * Return argument value for a given argument name.
    * 

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
@@ -183,9 +183,7 @@ public class CLKernelExecutor {
             openCLDefines.put("MAX_ARRAY_SIZE", MAX_ARRAY_SIZE); // needed for median. Median is limited to a given array length to be sorted
 
             if (constantsMap != null) {
-                for (String key : constantsMap.keySet()) {
-                    openCLDefines.put(key, constantsMap.get(key));
-                }
+                openCLDefines.putAll(constantsMap);
             }
 
             // deal with image width/height/depth for all images and buffers

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
@@ -252,9 +252,12 @@ public class CLKernelExecutor {
                         Object obj = parameterMap.get(key);
                         workaround.setArgument(key, obj);
                         if (obj instanceof ClearCLImageInterface) {
-                            workaround.setArgument("image_size_" + key + "_width", ((ClearCLImageInterface) obj).getWidth());
-                            workaround.setArgument("image_size_" + key + "_height", ((ClearCLImageInterface) obj).getHeight());
-                            workaround.setArgument("image_size_" + key + "_depth", ((ClearCLImageInterface) obj).getDepth());
+                            if(workaround.hasArgument("image_size_" + key + "_width"))
+                                workaround.setArgument("image_size_" + key + "_width", ((ClearCLImageInterface) obj).getWidth());
+                            if(workaround.hasArgument("image_size_" + key + "_height"))
+                                workaround.setArgument("image_size_" + key + "_height", ((ClearCLImageInterface) obj).getHeight());
+                            if(workaround.hasArgument("image_size_" + key + "_depth"))
+                                workaround.setArgument("image_size_" + key + "_depth", ((ClearCLImageInterface) obj).getDepth());
                         }
                     }
                 }

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/util/ElapsedTime.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/util/ElapsedTime.java
@@ -110,8 +110,12 @@ public class ElapsedTime
                         lElapsedTimeInMilliseconds,
                         pDescription);
 
-    if (lThrowable != null)
-      throw new RuntimeException(lThrowable);
+    if (lThrowable != null) {
+      if (lThrowable instanceof RuntimeException)
+        throw (RuntimeException) lThrowable;
+      else
+        throw new RuntimeException(lThrowable);
+    }
 
     return lElapsedTimeInMilliseconds;
   }


### PR DESCRIPTION
I would suggest to make these small changes.

* ElapsedTime: improve readability of exception's stack traces
  * Only wrap exception when needed, this makes the stack trace of the OpenCL exceptions a lot more readable.
* CLKErnelExecutor: small refactoring
  * That is a trivial change
* CLKernelExecuter: make image width, height and depth arguments optional
  * This change is debatable. It makes it easier to write low level kernels that don't use the clEsperanto dialect. Because it becomes possible to have a simple buffer argument like "global float* src" without the need to also add arguments  "image_size_src_width", etc.. I use it to run this kernel:
https://github.com/maarzt/imglib2-trainable-segmentation/blob/c9089460732a93ac0382ffd087128949309ec01e/src/test/resources/clij/gauss.cl#L1