### PR TITLE
Image memory manager

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
@@ -761,6 +761,7 @@ public class ClearCLBuffer extends ClearCLMemBase implements
   @Override
   public void close()
   {
+    mClearCLContext.removeImage(this);
     if (getPeerPointer() != null)
     {
       if (mBufferCleaner != null)
@@ -768,7 +769,6 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       getBackend().releaseBuffer(getPeerPointer());
       setPeerPointer(null);
     }
-    mClearCLContext.removeImageWithoutClosing(this);
   }
 
 

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
@@ -17,7 +17,6 @@ import net.haesleinhuepf.clij.coremem.ContiguousMemoryInterface;
 import net.haesleinhuepf.clij.coremem.enums.NativeTypeEnum;
 import net.haesleinhuepf.clij.coremem.rgc.Cleanable;
 import net.haesleinhuepf.clij.coremem.rgc.Cleaner;
-import net.haesleinhuepf.clij.coremem.rgc.RessourceCleaner;
 import net.haesleinhuepf.clij.coremem.util.Size;
 
 /**
@@ -769,7 +768,10 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       getBackend().releaseBuffer(getPeerPointer());
       setPeerPointer(null);
     }
+    mClearCLContext.removeImageWithoutClosing(this);
   }
+
+
 
   // NOTE: this _must_ be a static class, otherwise instances of this class will
   // implicitely hold a reference of this image...

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
@@ -25,7 +25,6 @@ import net.haesleinhuepf.clij.coremem.interop.NIOBuffersInterop;
 import net.haesleinhuepf.clij.coremem.offheap.OffHeapMemory;
 import net.haesleinhuepf.clij.coremem.rgc.Cleanable;
 import net.haesleinhuepf.clij.coremem.rgc.Cleaner;
-import net.haesleinhuepf.clij.coremem.rgc.RessourceCleaner;
 
 /**
  * ClearCLImage is the ClearCL abstraction for OpenCL images.
@@ -1088,6 +1087,7 @@ public class ClearCLImage extends ClearCLMemBase implements
       getBackend().releaseImage(getPeerPointer());
       setPeerPointer(null);
     }
+    mClearCLContext.removeImageWithoutClosing(this);
   }
 
   // NOTE: this _must_ be a static class, otherwise instances of this class will

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
@@ -1087,7 +1087,7 @@ public class ClearCLImage extends ClearCLMemBase implements
       getBackend().releaseImage(getPeerPointer());
       setPeerPointer(null);
     }
-    mClearCLContext.removeImageWithoutClosing(this);
+    mClearCLContext.removeImage(this);
   }
 
   // NOTE: this _must_ be a static class, otherwise instances of this class will

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImageInterfaceMemoryManager.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImageInterfaceMemoryManager.java
@@ -1,0 +1,106 @@
+package net.haesleinhuepf.clij.clearcl;
+
+import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLImageInterface;
+
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * This class keeps track of all ClearCLImages and ClearCLBuffers which are created by a
+ * ClearCLContext. In that way we can release them all by request or if the context is closed.
+ *
+ * Author: @haesleinhuepf
+ *         April 2020
+ */
+class ClearCLImageInterfaceMemoryManager extends ConcurrentSkipListSet<ClearCLImageInterface> {
+
+    @Override
+    public boolean remove(Object o) {
+        if (o instanceof ClearCLImageInterface) {
+            ((ClearCLImageInterface) o).close();
+        }
+        removeReleasedImages();
+        return super.remove(o);
+    }
+
+    /**
+     * Internal method for removing objects from the list without releasing memory behind.
+     * This is called from ClearCLImage and ClearCLBuffers when their close() method was called.
+     * @param o
+     */
+    void removeWithoutClosing(Object o) {
+        super.remove(o);
+    }
+
+    @Override
+    public void clear() {
+        for (ClearCLImageInterface image : this) {
+            image.close();
+        }
+        super.clear();
+    }
+
+    @Override
+    public boolean add(ClearCLImageInterface clearCLImageInterface) {
+        removeReleasedImages();
+        return super.add(clearCLImageInterface);
+    }
+
+    /**
+     * This method is called to release objects from the list which were called earlier.
+     * TODO: We might remove it.
+     */
+    private void removeReleasedImages() {
+        for (ClearCLImageInterface buffer : this) {
+            if (buffer.getPeerPointer() == null) {
+                remove(buffer);
+            }
+        }
+    }
+
+    /**
+     * Build up a human-readable list of all ClearCLImages and ClearCLBuffer which are
+     * managed here.
+     * @return list of objects and their allocated memory
+     */
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder();
+        long bytesSum = 0;
+        stringBuilder.append("GPU contains " + size() + " images.\n");
+        boolean wasClosedAlready = false;
+        for (ClearCLImageInterface buffer : this) {
+            String star = "";
+            if (buffer.getPeerPointer() == null) {
+                star = "*";
+                wasClosedAlready = true;
+            } else {
+                bytesSum = bytesSum + buffer.getSizeInBytes();
+            }
+
+            stringBuilder.append("- " + buffer.getName() + star + " " + humanReadableBytes(buffer.getSizeInBytes()) + " [" + buffer.toString() + "] " + humanReadableBytes(buffer.getSizeInBytes()) + "\n");
+        }
+        stringBuilder.append("= " + humanReadableBytes(bytesSum) +"\n");
+        if (wasClosedAlready) {
+            stringBuilder.append("  * Some images/buffers were closed already.\n");
+        }
+        return stringBuilder.toString();
+    }
+
+
+    private String humanReadableBytes(double bytesSum) {
+        if (bytesSum > 1024) {
+            bytesSum = bytesSum / 1024;
+            if (bytesSum > 1024) {
+                bytesSum = bytesSum / 1024;
+                if (bytesSum > 1024) {
+                    bytesSum = bytesSum / 1024;
+                    return (Math.round(bytesSum * 10.0) / 10.0 + " Gb");
+                } else {
+                    return (Math.round(bytesSum * 10.0) / 10.0 + " Mb");
+                }
+            } else {
+                return (Math.round(bytesSum * 10.0) / 10.0 + " kb");
+            }
+        }
+        return Math.round(bytesSum * 10.0) / 10.0 + " b";
+    }
+}

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
@@ -8,7 +8,6 @@ import net.haesleinhuepf.clij.clearcl.backend.ClearCLBackendInterface;
 import net.haesleinhuepf.clij.clearcl.enums.HostAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.KernelAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.MemAllocMode;
-import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLImageInterface;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemChangeListener;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
 
@@ -18,11 +17,8 @@ import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
  * @author royer
  */
 public abstract class ClearCLMemBase extends ClearCLBase
-                                     implements ClearCLMemInterface, Comparable
+                                     implements ClearCLMemInterface
 {
-  private int memobject_index;
-  private static int memobject_count = 0;
-  private static Object countLock = new Object();
 
   private final MemAllocMode mMemAllocMode;
   private final HostAccessType mHostAccessType;
@@ -55,10 +51,6 @@ public abstract class ClearCLMemBase extends ClearCLBase
     mMemAllocMode = pMemAllocMode;
     mHostAccessType = pHostAccessType;
     mKernelAccessType = pKernelAccessType;
-    synchronized (countLock) {
-      memobject_index = memobject_count;
-      memobject_count++;
-    }
   }
 
   /**
@@ -136,16 +128,4 @@ public abstract class ClearCLMemBase extends ClearCLBase
                          getPeerPointer());
   }
 
-  /**
-   * Memory objects are comparable (to order them) by allocation order.
-   * @param o object to copare to; must implement ClearCLMemBase
-   * @return relative index
-   */
-  @Override
-  public int compareTo(Object o) {
-    if (o instanceof ClearCLMemBase) {
-      return memobject_index - ((ClearCLMemBase) o).memobject_index;
-    }
-    return 1;
-  }
 }

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
@@ -8,6 +8,7 @@ import net.haesleinhuepf.clij.clearcl.backend.ClearCLBackendInterface;
 import net.haesleinhuepf.clij.clearcl.enums.HostAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.KernelAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.MemAllocMode;
+import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLImageInterface;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemChangeListener;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
 
@@ -17,8 +18,11 @@ import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
  * @author royer
  */
 public abstract class ClearCLMemBase extends ClearCLBase
-                                     implements ClearCLMemInterface
+                                     implements ClearCLMemInterface, Comparable
 {
+  private int memobject_index;
+  private static int memobject_count = 0;
+  private static Object countLock = new Object();
 
   private final MemAllocMode mMemAllocMode;
   private final HostAccessType mHostAccessType;
@@ -51,6 +55,10 @@ public abstract class ClearCLMemBase extends ClearCLBase
     mMemAllocMode = pMemAllocMode;
     mHostAccessType = pHostAccessType;
     mKernelAccessType = pKernelAccessType;
+    synchronized (countLock) {
+      memobject_index = memobject_count;
+      memobject_count++;
+    }
   }
 
   /**
@@ -128,4 +136,16 @@ public abstract class ClearCLMemBase extends ClearCLBase
                          getPeerPointer());
   }
 
+  /**
+   * Memory objects are comparable (to order them) by allocation order.
+   * @param o object to copare to; must implement ClearCLMemBase
+   * @return relative index
+   */
+  @Override
+  public int compareTo(Object o) {
+    if (o instanceof ClearCLMemBase) {
+      return memobject_index - ((ClearCLMemBase) o).memobject_index;
+    }
+    return 1;
+  }
 }

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/interfaces/ClearCLImageInterface.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/interfaces/ClearCLImageInterface.java
@@ -4,6 +4,7 @@ import java.nio.Buffer;
 
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
 import net.haesleinhuepf.clij.clearcl.ClearCLImage;
+import net.haesleinhuepf.clij.clearcl.ClearCLPeerPointer;
 import net.haesleinhuepf.clij.clearcl.backend.ClearCLBackendInterface;
 import net.haesleinhuepf.clij.coremem.ContiguousMemoryInterface;
 import net.haesleinhuepf.clij.coremem.enums.NativeTypeEnum;
@@ -172,5 +173,10 @@ public interface ClearCLImageInterface extends ClearCLMemInterface
 
   public String getName();
   public void setName(String name);
+
+  public ClearCLPeerPointer getPeerPointer();
+
+
+  public void close();
 
 }


### PR DESCRIPTION
Hey @maarzt,

I implemented the memory management as discussed:
* The context collects all buffers and images in a ConcurrentSkipListSet. Not sure if this is the right Set. I couldn't find another better suited concurrent set.
* As buffers and images have a reference to their context, they can remove themselfes from the contexts set when being closed.
* The ClearCLMemBase (mother of images and buffers) was made comparable in order to sort them in the list.
* This is also related to changes in clij2: https://github.com/clij/clij2/compare/refactor_image_data_manager

The stuff can be tested, e.g. with this macro:
https://github.com/clij/clij2-docs/blob/master/src/main/macro/allocateBigImages.ijm

Let me know what you think!

Cheers,
Robert