### PR TITLE
Image memory manager

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
@@ -761,6 +761,7 @@ public class ClearCLBuffer extends ClearCLMemBase implements
   @Override
   public void close()
   {
+    mClearCLContext.removeImage(this);
     if (getPeerPointer() != null)
     {
       if (mBufferCleaner != null)
@@ -768,7 +769,6 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       getBackend().releaseBuffer(getPeerPointer());
       setPeerPointer(null);
     }
-    mClearCLContext.removeImageWithoutClosing(this);
   }
 
 

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLImage.java
@@ -1087,7 +1087,7 @@ public class ClearCLImage extends ClearCLMemBase implements
       getBackend().releaseImage(getPeerPointer());
       setPeerPointer(null);
     }
-    mClearCLContext.removeImageWithoutClosing(this);
+    mClearCLContext.removeImage(this);
   }
 
   // NOTE: this _must_ be a static class, otherwise instances of this class will

--- a/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/abs/ClearCLMemBase.java
@@ -8,7 +8,6 @@ import net.haesleinhuepf.clij.clearcl.backend.ClearCLBackendInterface;
 import net.haesleinhuepf.clij.clearcl.enums.HostAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.KernelAccessType;
 import net.haesleinhuepf.clij.clearcl.enums.MemAllocMode;
-import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLImageInterface;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemChangeListener;
 import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
 
@@ -18,11 +17,8 @@ import net.haesleinhuepf.clij.clearcl.interfaces.ClearCLMemInterface;
  * @author royer
  */
 public abstract class ClearCLMemBase extends ClearCLBase
-                                     implements ClearCLMemInterface, Comparable
+                                     implements ClearCLMemInterface
 {
-  private int memobject_index;
-  private static int memobject_count = 0;
-  private static Object countLock = new Object();
 
   private final MemAllocMode mMemAllocMode;
   private final HostAccessType mHostAccessType;
@@ -55,10 +51,6 @@ public abstract class ClearCLMemBase extends ClearCLBase
     mMemAllocMode = pMemAllocMode;
     mHostAccessType = pHostAccessType;
     mKernelAccessType = pKernelAccessType;
-    synchronized (countLock) {
-      memobject_index = memobject_count;
-      memobject_count++;
-    }
   }
 
   /**
@@ -136,16 +128,4 @@ public abstract class ClearCLMemBase extends ClearCLBase
                          getPeerPointer());
   }
 
-  /**
-   * Memory objects are comparable (to order them) by allocation order.
-   * @param o object to copare to; must implement ClearCLMemBase
-   * @return relative index
-   */
-  @Override
-  public int compareTo(Object o) {
-    if (o instanceof ClearCLMemBase) {
-      return memobject_index - ((ClearCLMemBase) o).memobject_index;
-    }
-    return 1;
-  }
 }


### PR DESCRIPTION
Hi @haesleinhuepf,

1. Regarding the problem with the none existing `ConcurrentHashSet`. The solution is to use `ConcurrentHashMap.newKeySet()`. I reverted the comparable ClearCLMemBase commit. It locked very hacky to me.

2. I simplified the ClearCLImageMemoryManager. It's now really simple. The memory manager holds a set of images. Whenever a ClearCLImage is created, it is added to the set, whenever the ClearCLImage is closed, it is remove from the list. That way, the list always holds exactly one reference of every open images. Whenever the ClearCLContext is close, it closes all open images first. And it works exactly the same way with ClearCLBuffer.

3. I removed the Cleaner classes for ClearCLBuffer, ClearCLImage and CleareCLKernel. The where not used. And I am sure they want work in the future either. Because, using the Garbage Collector to free resources other than the heap memory is ****. It never works. It is horribly complicated and causes hard to find bugs. I could swear for hours about that garbage. But I'm interested: What where the problems that made you uncomment the ResourceCleaner in ClearCLBuffer and ClearCLImage?
