### PR TITLE
CLKernelExecutor: throw an exception when kernel execution fails

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/util/CLKernelExecutor.java
@@ -263,16 +263,9 @@ public class CLKernelExecutor {
                 }
             });
 
-            double duration = ElapsedTime.measure("Pure kernel execution", () -> {
-                try {
-                    workaround.run(waitToFinish);
-                } catch (Exception e) {
-                    e.printStackTrace();
-
-                    System.out.println(workaround.getSourceCode());
-                }
+            ElapsedTime.measure("Pure kernel execution", () -> {
+               workaround.run(waitToFinish);
             });
-            //clearCLKernel.close();
         }
 
         return kernel;


### PR DESCRIPTION
I have the following problem. I call a kernel. The kernel fails, with an CL_MEM_OBJECT_ALLOCATION_FAILURE. An error message is printed on the console.
But the code continues, as if there was no failure. And I get wrong results. This is really bad,
the caller has no way to notice the failure an react accordingly.

This PR changes the CLKernelExecutor.enqueue(...) method to throw an OpenCLException with
the error code (CL_MEM_OBJECT_ALLOCATION_FAILURE). This allows my code to catch
the exception, and recognize the out-of-memore-failure. I then free some memory, and rerun the kernel.