### PR TITLE
Fix multi channel ClearCLBuffer, methods readTo and writeFrom

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/ClearCLBuffer.java
@@ -169,9 +169,9 @@ public class ClearCLBuffer extends ClearCLMemBase implements
                      boolean pBlockingCopy)
   {
     if ((pOffsetInSrcBuffer + pLengthInElements)
-        * getPixelSizeInBytes() > getSizeInBytes()
+        * getNativeType().getSizeInBytes() > getSizeInBytes()
         || (pOffsetInDstBuffer + pLengthInElements)
-           * getPixelSizeInBytes() > pDstBuffer.getSizeInBytes())
+           * getNativeType().getSizeInBytes() > pDstBuffer.getSizeInBytes())
       throw new ClearCLException("Incompatible length");
 
     getBackend().enqueueCopyBuffer(mClearCLContext.getDefaultQueue()
@@ -335,9 +335,9 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       throw new ClearCLHostAccessException("Image not readable from host");
 
     if ((pOffsetInBuffer + pLengthInBuffer)
-        * getPixelSizeInBytes() > pContiguousMemory.getSizeInBytes()
+        * getNativeType().getSizeInBytes() > pContiguousMemory.getSizeInBytes()
         || (pOffsetInBuffer + pLengthInBuffer)
-           * getPixelSizeInBytes() > getSizeInBytes())
+           * getNativeType().getSizeInBytes() > getSizeInBytes())
       throw new ClearCLException("Incompatible length");
 
     ClearCLPeerPointer lHostMemPointer =
@@ -390,9 +390,9 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       throw new ClearCLHostAccessException("Image not readable from host");
 
     if ((pOffsetInBuffer + pLengthInBuffer)
-        * getPixelSizeInBytes() > Size.ofBuffer(pBuffer)
+        * getNativeType().getSizeInBytes() > Size.ofBuffer(pBuffer)
         || (pOffsetInBuffer + pLengthInBuffer)
-           * getPixelSizeInBytes() > getSizeInBytes())
+           * getNativeType().getSizeInBytes() > getSizeInBytes())
       throw new ClearCLException("Incompatible length");
 
     ClearCLPeerPointer lHostMemPointer = getBackend().wrap(pBuffer);
@@ -445,9 +445,9 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       throw new ClearCLHostAccessException("Image not writable from host");
 
     if ((pOffsetInBuffer + pLengthInBuffer)
-        * getPixelSizeInBytes() > pContiguousMemory.getSizeInBytes()
+        * getNativeType().getSizeInBytes() > pContiguousMemory.getSizeInBytes()
         || (pOffsetInBuffer + pLengthInBuffer)
-           * getPixelSizeInBytes() > getSizeInBytes())
+           * getNativeType().getSizeInBytes() > getSizeInBytes())
       throw new ClearCLException("Incompatible length");
 
     ClearCLPeerPointer lHostMemPointer =
@@ -501,9 +501,9 @@ public class ClearCLBuffer extends ClearCLMemBase implements
       throw new ClearCLHostAccessException("Image not writable from host");
 
     if ((pOffsetInBuffer + pLengthInBuffer)
-        * getPixelSizeInBytes() > Size.ofBuffer(pBuffer)
+        * getNativeType().getSizeInBytes() > Size.ofBuffer(pBuffer)
         || (pOffsetInBuffer + pLengthInBuffer)
-           * getPixelSizeInBytes() > getSizeInBytes())
+           * getNativeType().getSizeInBytes() > getSizeInBytes())
       throw new ClearCLException("Incompatible length");
 
     ClearCLPeerPointer lHostMemPointer = getBackend().wrap(pBuffer);

--- a/src/test/java/net/haesleinhuepf/clij/clearcl/ClearCLBufferTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/clearcl/ClearCLBufferTest.java
@@ -1,0 +1,32 @@
+package net.haesleinhuepf.clij.clearcl;
+
+import net.haesleinhuepf.clij.clearcl.backend.jocl.ClearCLBackendJOCL;
+import net.haesleinhuepf.clij.clearcl.enums.HostAccessType;
+import net.haesleinhuepf.clij.clearcl.enums.KernelAccessType;
+import net.haesleinhuepf.clij.clearcl.enums.MemAllocMode;
+import net.haesleinhuepf.clij.coremem.enums.NativeTypeEnum;
+import org.junit.Test;
+
+import java.nio.FloatBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ClearCLBufferTest {
+
+	@Test
+	public void test() {
+		float[] expected = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+		float[] result = new float[16];
+		try (
+				ClearCL clearCL = new ClearCL(new ClearCLBackendJOCL());
+				ClearCLDevice device = clearCL.getBestGPUDevice();
+				ClearCLContext context = device.createContext();
+				ClearCLBuffer buffer = context.createBuffer(MemAllocMode.Best, HostAccessType.ReadWrite,
+						KernelAccessType.ReadWrite, 2, NativeTypeEnum.Float, 2, 2, 2);
+		) {
+			buffer.readFrom(FloatBuffer.wrap(expected), true);
+			buffer.writeTo(FloatBuffer.wrap(result), true);
+		}
+		assertArrayEquals(expected, result, 0);
+	}
+}

--- a/src/test/java/net/haesleinhuepf/clij/clearcl/ClearCLImageTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/clearcl/ClearCLImageTest.java
@@ -1,17 +1,16 @@
 package net.haesleinhuepf.clij.clearcl;
 
 import net.haesleinhuepf.clij.clearcl.backend.jocl.ClearCLBackendJOCL;
-import net.haesleinhuepf.clij.clearcl.enums.HostAccessType;
-import net.haesleinhuepf.clij.clearcl.enums.KernelAccessType;
-import net.haesleinhuepf.clij.clearcl.enums.MemAllocMode;
-import net.haesleinhuepf.clij.coremem.enums.NativeTypeEnum;
+import net.haesleinhuepf.clij.clearcl.enums.ImageChannelDataType;
+import net.haesleinhuepf.clij.clearcl.enums.ImageChannelOrder;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class ClearCLBufferTest {
+public class ClearCLImageTest {
 
 	@Test
 	public void testReadFromAndWriteTo() {
@@ -21,11 +20,15 @@ public class ClearCLBufferTest {
 				ClearCL clearCL = new ClearCL(new ClearCLBackendJOCL());
 				ClearCLDevice device = clearCL.getBestGPUDevice();
 				ClearCLContext context = device.createContext();
-				ClearCLBuffer buffer = context.createBuffer(MemAllocMode.Best, HostAccessType.ReadWrite,
-						KernelAccessType.ReadWrite, 2, NativeTypeEnum.Float, 2, 2, 2);
+				ClearCLImage buffer = context.createImage(ImageChannelOrder.RG, ImageChannelDataType.Float,
+						2, 2, 2)
 		) {
-			buffer.readFrom(FloatBuffer.wrap(expected), true);
-			buffer.writeTo(FloatBuffer.wrap(result), true);
+			FloatBuffer in = ByteBuffer.allocateDirect(expected.length * Float.BYTES).asFloatBuffer();
+			in.put(expected);
+			buffer.readFrom(in, true);
+			FloatBuffer out = ByteBuffer.allocateDirect(result.length * Float.BYTES).asFloatBuffer();
+			buffer.writeTo(out, true);
+			out.get(result);
 		}
 		assertArrayEquals(expected, result, 0);
 	}


### PR DESCRIPTION
A ClearCLBuffer can have multiple channels.
But for multi channel ClearCLBuffers, the readFrom and writeTo methods throw a ClearCLException("Incompatible length").
This exception is cause by a wrong calculation of the allowed length for the input and output buffer.
This PR fixes the calculation of the allowed buffer length.