### PR TITLE
Fix multithreaded call to ClearCL().getNumberOfPlatforms().

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCL.java
+++ b/src/main/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCL.java
@@ -81,9 +81,13 @@ public class ClearCLBackendJOCL extends ClearCLBackendBase
   {
     return BackendUtils.checkExceptions(() -> {
       final int numPlatformsArray[] = new int[1];
-      BackendUtils.checkOpenCLError(clGetPlatformIDs(0,
-                                                     null,
-                                                     numPlatformsArray));
+      synchronized (CL.class) {
+        // The call to CL.clGetPlatformIDs must be synchronized.
+        // At least on Ubuntu 16.04, NVIDIA GTX960M, Driver Version 410.129.
+        BackendUtils.checkOpenCLError(clGetPlatformIDs(0,
+                null,
+                numPlatformsArray));
+      }
       final int lNumberOfPlatforms = numPlatformsArray[0];
       return lNumberOfPlatforms;
     });

--- a/src/test/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCLTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/clearcl/backend/jocl/ClearCLBackendJOCLTest.java
@@ -1,0 +1,40 @@
+package net.haesleinhuepf.clij.clearcl.backend.jocl;
+
+import org.jocl.CL;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link ClearCLBackendJOCL}
+ */
+public class ClearCLBackendJOCLTest {
+
+	@Test
+	public void testMultiThreadedGetNumberOfPlatforms() throws InterruptedException {
+		// NB: This test failed, on Ubuntu 16.04, with NVIDIA GTX960M, Driver Version 410.129, when the calls
+		//     to CL.clGetPlatformIDs() where not synchronized.
+		int numThreads = 10;
+		CountDownLatch finishSignal = new CountDownLatch(numThreads);
+		List<Exception> exceptions = new LinkedList<>();
+		for (int i = 0; i < 10; i++) {
+			new Thread(() -> {
+				try {
+					new ClearCLBackendJOCL().getNumberOfPlatforms();
+				} catch (Exception exception) {
+					exceptions.add(exception);
+				}
+				finishSignal.countDown();
+			}).start();
+		}
+		// wait for all threads to finish
+		finishSignal.await();
+		// make sure there where no exceptions
+		assertEquals(Collections.emptyList(), exceptions);
+	}
+}


### PR DESCRIPTION
I got exceptions when creating new CLIJ() in parallel, in multi threads.
This commit fixes this problem.